### PR TITLE
Maybe it is good to add check in clearTimeout and clearInterval

### DIFF
--- a/src/main/resources/js/event-loop.js
+++ b/src/main/resources/js/event-loop.js
@@ -104,7 +104,7 @@
    * @param {Object} task timeout handle
    */
   function clearTimeout(task) {
-    if (task.cancel()) {
+    if (task && task.cancel()) {
       phaser.arriveAndDeregister();
     }
   }
@@ -142,7 +142,7 @@
    * @param {Object} interval handle
    */
   function clearInterval(task) {
-    if (task.cancel()) {
+    if (task && task.cancel()) {
       phaser.arriveAndDeregister();
     }
   }


### PR DESCRIPTION
I try to use nashorn-async to enable promise-7.0.4.min.js for pdf-lib.js running in nashorn. It is almost sucessful now, thanks for your nashorn-async.
I found an error because of calling clearInterval before setInterval in promise-7.0.4.min.js. And the next test codes show browsers will not throw anything, 
```
var a; clearInterval(a);
```
so  I think maybe a check should be add in clearTimeout and clearInterval.
```
if (task && task.cancel()) {
   phaser.arriveAndDeregister();
}
```